### PR TITLE
Fixed #2985.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,18 +36,19 @@
   },
   "homepage": "https://github.com/wikimedia/mathoid",
   "dependencies": {
+    "MathJax-node": "git+https://github.com/wikimedia/MathJax-node#mathoid-0-2-8",
     "bluebird": "~2.8.2",
     "body-parser": "^1.13.2",
     "bunyan": "^1.4.0",
     "cassandra-uuid": "^0.0.2",
     "compression": "^1.5.1",
     "domino": "^1.0.18",
+    "encodeurl": "^1.0.1",
     "express": "^4.13.1",
     "js-yaml": "^3.3.1",
     "preq": "^0.4.4",
     "service-runner": "^0.2.1",
-    "texvcjs": "git+https://github.com/wikimedia/texvcjs",
-    "MathJax-node": "git+https://github.com/wikimedia/MathJax-node#mathoid-0-2-8"
+    "texvcjs": "git+https://github.com/wikimedia/texvcjs"
   },
   "devDependencies": {
     "coveralls": "2.11.2",
@@ -60,7 +61,9 @@
   "deploy": {
     "target": "ubuntu",
     "dependencies": {
-      "_all": ["openjdk-7-jre-headless"]
+      "_all": [
+        "openjdk-7-jre-headless"
+      ]
     }
   }
 }

--- a/routes/mathoid.js
+++ b/routes/mathoid.js
@@ -4,6 +4,7 @@
 var sUtil = require('../lib/util');
 var texvcjs = require('texvcjs');
 var HTTPError = sUtil.HTTPError;
+var encodeUrl = require('encodeurl');
 
 
 /**
@@ -48,7 +49,7 @@ function handleRequest(res, q, type, outFormat, speakText) {
          * returns them as a HTTP Warning.
          */
         if (sanitizationOutput.status !== '+') {
-            res.set('Warning', sanitizationOutput.status + ' - ' + sanitizationOutput.details);
+            res.set('Warning', encodeUrl(sanitizationOutput.status + ' - ' + sanitizationOutput.details));
         }
     }
     mml = outFormat === "mml" || outFormat === "json";


### PR DESCRIPTION
Encode error details to make sure non-ASCII characters can go into header fields.